### PR TITLE
Improve middleware func with filter of type string

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ func filter(c echo.Context) bool {
 func main() {
 	e := echo.New()
 	// simple apply middleware without filter
-	e.Use(echolog.Middleware())
+	e.Use(echolog.Default())
 	// with filter
-	e.Use(echolog.Middleware("/healthcheck"))
+	e.Use(echolog.Default("/healthcheck"))
 	// add more filter
-	e.Use(echolog.Middleware("/healthcheck", "foo", "bar"))
+	e.Use(echolog.Default("/healthcheck", "foo", "bar"))
 	
 	// you can also do this
-	e.Use(echolog.MiddlewareFilterFunc(filter))
+	e.Use(echolog.Middleware(filter))
 	// or without filter
-	// e.Use(echolog.MiddlewareFilterFunc(nil))
+	// e.Use(echolog.Middleware(nil))
 	// Output: {"level":"info","request_id":"9627a4a0-9d94-4ab6-844c-9599c0a15cd0","remote_ip":"[::1]:62542","host":"localhost:8080","method":"GET","path":"/","body":"","status_code":200,"latency":0,"tag":"request","time":"2023-02-19T14:07:37+07:00","message":"success"}
 
 	e.GET("/", func(c echo.Context) error {

--- a/README.md
+++ b/README.md
@@ -26,11 +26,18 @@ func filter(c echo.Context) bool {
 
 func main() {
 	e := echo.New()
-	e.Use(echolog.Middleware(filter))
+	// simple apply middleware without filter
+	e.Use(echolog.Middleware())
+	// with filter
+	e.Use(echolog.Middleware("/healthcheck"))
+	// add more filter
+	e.Use(echolog.Middleware("/healthcheck", "foo", "bar"))
+	
+	// you can also do this
+	e.Use(echolog.MiddlewareFilterFunc(filter))
+	// or without filter
+	// e.Use(echolog.MiddlewareFilterFunc(nil))
 	// Output: {"level":"info","request_id":"9627a4a0-9d94-4ab6-844c-9599c0a15cd0","remote_ip":"[::1]:62542","host":"localhost:8080","method":"GET","path":"/","body":"","status_code":200,"latency":0,"tag":"request","time":"2023-02-19T14:07:37+07:00","message":"success"}
-
-	// Or without filter
-	// r.Use(echolog.Middleware(nil))
 
 	e.GET("/", func(c echo.Context) error {
 		ctx := c.Request().Context()

--- a/echolog.go
+++ b/echolog.go
@@ -51,8 +51,8 @@ func (l *logFields) MarshalZerologObject(e *zerolog.Event) {
 	}
 }
 
-// Middleware contains functionality of request_id, logger and recover for request traceability
-func Middleware(filter func(c echo.Context) bool) echo.MiddlewareFunc {
+// MiddlewareFilterFunc contains functionality of request_id, logger and recover for request traceability
+func MiddlewareFilterFunc(filter func(c echo.Context) bool) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 
@@ -141,6 +141,27 @@ func Middleware(filter func(c echo.Context) bool) echo.MiddlewareFunc {
 			return next(c)
 		}
 	}
+}
+
+// Middleware contains functionality to filter Request URI with paramater type of string
+func Middleware(filters ...string) echo.MiddlewareFunc {
+	if len(filters) > 0 {
+		return MiddlewareFilterFunc(func(c echo.Context) bool {
+			return filtered(c, filters)
+		})
+	}
+
+	return MiddlewareFilterFunc(nil)
+}
+
+func filtered(c echo.Context, filters []string) bool {
+	for _, filter := range filters {
+		if c.Request().RequestURI == filter {
+			return true
+		}
+	}
+
+	return false
 }
 
 func formatReqBody(data []byte) string {

--- a/echolog.go
+++ b/echolog.go
@@ -51,8 +51,8 @@ func (l *logFields) MarshalZerologObject(e *zerolog.Event) {
 	}
 }
 
-// MiddlewareFilterFunc contains functionality of request_id, logger and recover for request traceability
-func MiddlewareFilterFunc(filter func(c echo.Context) bool) echo.MiddlewareFunc {
+// Middleware contains functionality of request_id, logger and recover for request traceability
+func Middleware(filter func(c echo.Context) bool) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 
@@ -146,12 +146,12 @@ func MiddlewareFilterFunc(filter func(c echo.Context) bool) echo.MiddlewareFunc 
 // Middleware contains functionality to filter Request URI with paramater type of string
 func Middleware(filters ...string) echo.MiddlewareFunc {
 	if len(filters) > 0 {
-		return MiddlewareFilterFunc(func(c echo.Context) bool {
+		return Middleware(func(c echo.Context) bool {
 			return filtered(c, filters)
 		})
 	}
 
-	return MiddlewareFilterFunc(nil)
+	return Middleware(nil)
 }
 
 func filtered(c echo.Context, filters []string) bool {

--- a/echolog.go
+++ b/echolog.go
@@ -143,8 +143,8 @@ func Middleware(filter func(c echo.Context) bool) echo.MiddlewareFunc {
 	}
 }
 
-// Middleware contains functionality to filter Request URI with paramater type of string
-func Middleware(filters ...string) echo.MiddlewareFunc {
+// Default contains functionality to filter Request URI with paramater type of string
+func Default(filters ...string) echo.MiddlewareFunc {
 	if len(filters) > 0 {
 		return Middleware(func(c echo.Context) bool {
 			return filtered(c, filters)


### PR DESCRIPTION
## Improve middleware filter functionality 

- menyederhanakan apply filter middleware dengan function _Default()_ untuk simple usecase
- apply filter menggunakan [variadic functions](https://gobyexample.com/variadic-functions) dengan arguments type string
- apply filter function arguments dapat dikosongkan (optional) karena menggunakan [variadic functions](https://gobyexample.com/variadic-functions)

- update README.md

```go
r.Use(echolog.Default())
``` 
atau
```go
r.Use(echolog.Default("healthcheck", "foo"))
``` 